### PR TITLE
optimize CourseSection admin view (fix issue #1)

### DIFF
--- a/main/admin.py
+++ b/main/admin.py
@@ -1,5 +1,10 @@
-from main.models import *
+from django.contrib import admin
 from django.contrib.admin import site
+from main.models import *
+from main.forms import CourseSectionForm
+
+class CourseSectionAdmin(admin.ModelAdmin):
+    form = CourseSectionForm
 
 site.register(Variable)
 site.register(Configuration)
@@ -7,4 +12,4 @@ site.register(UserInput)
 
 site.register(Game)
 site.register(State)
-site.register(CourseSection)
+site.register(CourseSection, CourseSectionAdmin)

--- a/main/forms.py
+++ b/main/forms.py
@@ -1,0 +1,13 @@
+from django import forms
+from main.models import (CourseSection,
+                         State)
+
+class CourseSectionForm(forms.ModelForm):
+    class Meta:
+        model = CourseSection
+
+    def __init__(self, *args, **kw):
+        forms.ModelForm.__init__(self, *args, **kw)
+        ## https://github.com/ccnmtl/mvsim/issues/1
+        self.fields['starting_states'].queryset = State.objects.filter(game__isnull=True)
+


### PR DESCRIPTION
See https://github.com/ccnmtl/mvsim/issues/1 -- this patch constrains the admin view's queryset to states with `game=NULL`.  This should make the view at `/admin/main/coursesection/` usable: without the patch, the view inadvertently makes _N+1 separate database queries_ where N is the number of turns played across all games by all users in all courses.  With the patch, the system should make one database query.
