### PR TITLE
boto -> boto3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ testtools==2.3.0
 testscenarios==0.5.0
 python-subunit==1.3.0
 sqlparse==0.3.0
-boto==2.49.0
+boto3==1.9.171
 six==1.12.0
 python-dateutil==2.8.0
 gunicorn==19.9.0


### PR DESCRIPTION
boto is not supported on python 3.6 - boto3 is the new package.
This is used by django-storages, which apparently already supports
boto3:
https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html