### PR TITLE
Fix TypeError: can't multiply sequence by non-int of type 'float'

### DIFF
--- a/engine/logic.py
+++ b/engine/logic.py
@@ -306,7 +306,7 @@ class Turn:
 
         num_bednets = len([elem for elem in self.state.owned_items
                            if elem == "bednet"])
-        needed_bednets = self.state.population / 2
+        needed_bednets = int(self.state.population / 2)
 
         if num_bednets < needed_bednets:
             self.message('NGO bednets')

--- a/engine/tests.py
+++ b/engine/tests.py
@@ -763,6 +763,15 @@ class TestTurn(unittest.TestCase):
     def tearDown(self):
         self.turn = None
 
+    def test_free_bednets(self):
+        self.turn.coeffs.enable_free_bednets = True
+        self.turn.state.year = (self.turn.coeffs.starting_year +
+                                self.turn.coeffs.free_bednet_year)
+        self.turn.free_bednets()
+
+        self.assertTrue('bednet' in self.turn.state.owned_items)
+        self.assertEqual(len(self.turn.state.bednet_ages), 2)
+
     def test_calc_maximum_effort(self):
         assert self.turn.calc_maximum_effort() == 2
 


### PR DESCRIPTION
The `needed_bednets` was coming through as a float, which blows up the extend.
Convert to an int to resolve.