### PR TITLE
Pin setuptools <58

### DIFF
--- a/django.mk
+++ b/django.mk
@@ -47,7 +47,7 @@ $(PY_SENTINAL): $(REQUIREMENTS)
 	rm -rf $(VE)
 	$(SYS_PYTHON) -m venv $(VE)
 	$(PIP) install pip==$(PIP_VERSION)
-	$(PIP) install --upgrade setuptools
+	$(PIP) install setuptools==57.5.0
 	$(PIP) install wheel==$(WHEEL_VERSION)
 	$(PIP) install --no-deps --requirement $(REQUIREMENTS) --no-binary cryptography
 	touch $@


### PR DESCRIPTION
setuptools v58 removed support for use_2to3. the tempita dependency here breaks as it uses 2to3, and there is not currently an update. For the moment, pin setuptools with the hope that someone will fork & update.