### PR TITLE
Fix access denied issue in admin console

### DIFF
--- a/mvsim/templates/admin/login.html
+++ b/mvsim/templates/admin/login.html
@@ -3,7 +3,7 @@
 
 {% block title %}Log In{% endblock %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "/media/admin/css/login.css" %}" />{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "media/admin/css/login.css" %}" />{% endblock %}
 
 {% block bodyclass %}login{% endblock %}
 


### PR DESCRIPTION
Removing the initial slash in the `{%static %}` reference should fix the Bad Request 400 error.